### PR TITLE
Start LCS Draft 5 - LCS Project Code of Conduct

### DIFF
--- a/drafts/LCSD5.md
+++ b/drafts/LCSD5.md
@@ -93,7 +93,6 @@ The Code of Conduct shall apply to:
 7. Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, indicate this to either the LCS Leads or the relevant Working Committee(s). Whether you’re a regular contributor or a newcomer, we care about making this community a safe place for you and we’ve got your back.
 8. Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
 
-
 ## §5 Adoption and Amendments
 
 Publication of this Specification shall be by a Unanimous Vote of the LCS Leads. Except as provided otherwise, any Primary Publication that amends this Publication shall also be published only by a Unanimous Vote.

--- a/drafts/LCSD5.md
+++ b/drafts/LCSD5.md
@@ -26,10 +26,11 @@ The Code of Conduct is Established pursuant to the LCS Project Charter.
 
 The Code of Conduct Technical Working Committee shall be established to make special publications related to the code of conduct, and to review drafts amending the Code of Conduct. In particular, the Working Committee shall review drafts that:
 * Amend any part of §3 or §4 of this Publication,
-* Establish any new rule under the Code of Conduct, or
+* Establish any new principle or applicability provision of the Code of Conduct, or
 * Establish any uniform enforcement rules for the Code of Conduct.
 
 The Code of Conduct Working Committee may make special publications regarding Working Committee Rules and its Working Committee Code of Conduct. It may additionally make Special Publications regarding:
+* Implement any rule consistent with §4 and other Publications that apply to the Applicability and Principles of the Code of Conduct,
 * Interpretations or Clarifications of the Code of Conduct in this or any other Publication,
 * Suggestions for Uniform enforcement by Working Committees, and
 * Suggested enforcement penalties, at both the Project and Working Committee level.
@@ -42,7 +43,7 @@ Until an abreviated name is assigned to the Code of Conduct Working Committee, i
 
 The LCS Leads shall have the sole authority to enforce the Code of Conduct in a manner that applies to the entire project. Such enforcement shall be by Majority Vote.
 
-The LC Admins shall have the authority to enforce the Code of Conduct in such a manner, when their intervention has been requested by the LCS Leads *or* if they may intervening without request, provided that that the situation to which the enforcement applies exceeds the boundaries of the LCS Project and affects LC as a whole.
+The LC Admins shall have the authority to enforce the Code of Conduct in such a manner, when their intervention has been requested by the LCS Leads *or* if they may intervene without request, provided that that the situation to which the enforcement applies exceeds the boundaries of the LCS Project and affects LC as a whole.
 
 No project-level enforcement shall be overturned or questioned by any Working Committee.
 

--- a/drafts/LCSD5.md
+++ b/drafts/LCSD5.md
@@ -1,0 +1,114 @@
+# LCS 2 - LCS Project Code of Conduct
+
+Start Date: 2023-11-27
+
+Contact: Connor Horman <chorman@lcdev.xyz>
+
+Last Revision Date: 2023-11-27
+
+Last Review Date: 
+
+Revision Number: 0
+
+Target Working Committee: Governance and Membership.
+
+This document is a Draft.
+
+Copyright (C) 2023 Connor Horman. License Notice is present in §7.
+
+## §1 LCS Project Code of Conduct Established
+
+This Document Establishes a Code of Conduct which applies accross the LCS Project, to all LCS Publications (Primary, Draft, and Special), and to all communications, public and private, of the LCS Leads, and of any Working Committee.
+
+The Code of Conduct is Established pursuant to the LCS Project Charter.
+
+## §2 Code of Conduct Working Committee
+
+The Code of Conduct Technical Working Committee shall be established to make special publications related to the code of conduct, and to review drafts amending the Code of Conduct. In particular, the Working Committee shall review drafts that:
+* Amend any part of §3 or §4 of this Publication,
+* Establish any new rule under the Code of Conduct, or
+* Establish any uniform enforcement rules for the Code of Conduct.
+
+The Code of Conduct Working Committee may make special publications regarding Working Committee Rules and its Working Committee Code of Conduct. It may additionally make Special Publications regarding:
+* Interpretations or Clarifications of the Code of Conduct in this or any other Publication,
+* Suggestions for Uniform enforcement by Working Committees, and
+* Suggested enforcement penalties, at both the Project and Working Committee level.
+
+Until an abreviated name is assigned to the Code of Conduct Working Committee, it shall be COC. 
+
+## §3 Enforcement of the Code of Conduct
+
+### §3.1 Enforcement Project Wide
+
+The LCS Leads shall have the sole authority to enforce the Code of Conduct in a manner that applies to the entire project. Such enforcement shall be by Majority Vote.
+
+The LC Admins shall have the authority to enforce the Code of Conduct in such a manner, when their intervention has been requested by the LCS Leads *or* if they may intervening without request, provided that that the situation to which the enforcement applies exceeds the boundaries of the LCS Project and affects LC as a whole.
+
+No project-level enforcement shall be overturned or questioned by any Working Committee.
+
+Project-level enforcement may include, but is not limited to, the following:
+* Removal from and/or a prohibition from serving on any Working Committee, 
+* A prohibition from submitting or acting as a contact on any publication,
+* Removal of any publication, including a Draft or Special Publication, and
+* A prohibition from communicating with members and Working Committees of the project in some or all applicable manners.
+
+### §3.2 Enforcement in each Working Committee
+
+Each Working Committee shall have the authority to enforce the Code of Conduct at the level of that Working Committee. Such enforcement shall occur according to the Working Committee rules. 
+
+Working Committee-level enfrocement may include, but is not limited to, the following:
+* Removal from and/or prohibition from serving on the Working Committee,
+* Prohibition from submitting or acting as a contact on any publication submitted to the Working Committee,
+* Removal of any Draft or Special Publication targetted at or reviewed by the Working Committe, and
+* A prohibition from communicating with the Working Committee in some or all ppplicable manners.
+
+### §3.3 Adherence by Publications
+
+Each Publication of any kind (Primary, Draft, and Special) must adhere to all rules of the Code of Conduct which are in existance at the time it is published. 
+
+If an amendment to the Code of Conduct leaves any publication that already exists in violation of any of its rules, it may be removed by the LCS Leads, or, in the case of a Draft Publication or Special Publication, the Working Committee in charge of the publication. Otherwise, it shall not be required to adhere to the rules which did not exist when it was published, except that a Draft Publication or a Special Publication shall adhere to such rules when it is revised after the rule takes effect.
+
+## §4 Code of Conduct
+
+### §4.1 Application of the Code of Conduct
+
+The Code of Conduct shall apply to:
+* All communications monitored or managed by the project, including all communications to any Working Committee,
+* Any submission made to apply for a Draft or Publication Number,
+* Any publication of any kind (Primary, Draft, or Special),
+* Any public communication by any member of any Working Committee or any Lead,
+* Any private communication made by or to any member of a Working Committee or by a Lead, in any context related to the LCS Project, or LC as a whole, 
+* Any decision made by any Working Committee, whether or not it is made publically or privately, and
+* Any other context that impacts public confidence in the LCS Project or LC as a whole, or that enforcing group believes prevents or would prevent the involved parties from constructively participating in the LCS Project.
+
+### §4.2 Principles of the Code of Conduct
+
+1. We are committed to providing a friendly, safe and welcoming environment for all who wish to participate, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
+2. Please avoid using overtly sexual aliases or other nicknames that might detract from a friendly, safe and welcoming environment for all.
+3. Please be kind and courteous. There’s no need to be mean or rude.
+4. Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.
+5. Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.
+6. We will exclude you from interaction if you insult, demean or harass anyone. That is not welcome behavior. The term “harassment” is to be interpereted as including the definition in the [Citizen Code of Conduct](https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md); if you have any lack of clarity about what might be included in that concept, please read their definition. In particular, we don’t tolerate behavior that excludes people in socially marginalized groups.
+7. Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, indicate this to either the LCS Leads or the relevant Working Committee(s). Whether you’re a regular contributor or a newcomer, we care about making this community a safe place for you and we’ve got your back.
+8. Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
+
+
+## §5 Adoption and Amendments
+
+Publication of this Specification shall be by a Unanimous Vote of the LCS Leads. Except as provided otherwise, any Primary Publication that amends this Publication shall also be published only by a Unanimous Vote.
+
+The Governance and Membership Working Committee shall have purview over reviewing any draft that amends any section other than §4. The Code of Conduct Working Committee shall have purview over reviewing any draft that amends §3 or §4. In the case where the Draft amends §3 or amends both §4 and any other section, then both Working Committees shall have purview and both shall be targetted by the Draft.
+
+Any Primary Publication that amends only §2, §3 other than §3.1, or §5, may be published on a Majority Vote of the LCS Leads. 
+
+## §6 Non-exclusive with Working Committee Codes of Conduct
+
+All portions of this Code of Conduct apply in addition to, but not instead of or exclusively to, any Code of Conduct which any Working Committee adopts for its members.
+
+Working Committees that establish a Code of Conduct may enforce that Code of Conduct in any manner it is permitted to enforce the LCS Project Code of Conduct. 
+
+## §7 Copyright License
+
+This document is released under the terms of the CC BY 4.0. You may copy, distribute, publish, modify, or otherwise use this document provided that this notice is left intact and that you do not use technological measures to prevent further use.
+
+A Copy of the license is accessible at <https://creativecommons.org/licenses/by/4.0/legalcode.en>.

--- a/drafts/LCSD5.md
+++ b/drafts/LCSD5.md
@@ -99,7 +99,7 @@ Publication of this Specification shall be by a Unanimous Vote of the LCS Leads.
 
 The Governance and Membership Working Committee shall have purview over reviewing any draft that amends any section other than §4. The Code of Conduct Working Committee shall have purview over reviewing any draft that amends §3 or §4. In the case where the Draft amends §3 or amends both §4 and any other section, then both Working Committees shall have purview and both shall be targetted by the Draft.
 
-Any Primary Publication that amends only §2, §3 other than §3.1, or §5, may be published on a Majority Vote of the LCS Leads. 
+Any Primary Publication that amends only §2, §3 other than §3.1, or §4, may be published on a Majority Vote of the LCS Leads. 
 
 ## §6 Non-exclusive with Working Committee Codes of Conduct
 


### PR DESCRIPTION
Establishes the project-wide baseline Code of Conduct for the LCS Project. Also will establish a Working Committee that can make Special Publications related to Code of Conduct enforcement, and reviews drafts aimed at amending the Code of Conduct.
